### PR TITLE
Adding loglevel feature

### DIFF
--- a/lib/puppet/type/echo.rb
+++ b/lib/puppet/type/echo.rb
@@ -25,6 +25,11 @@ Puppet::Type.newtype(:echo) do
     newvalues(:true, :false)
   end
 
+  newparam(:loglevel) do
+    defaultto :notice
+    newvalues(:debug, :info, :notice, :warning, :err, :alert, :emerg, :crit)
+  end
+
   def refresh
     output
   end
@@ -34,6 +39,6 @@ Puppet::Type.newtype(:echo) do
     if parameters[:withpath].value != :false
       msg = "#{path}/message: #{msg}"
     end
-    Puppet.notice(msg)
+    Puppet.public_send(self[:loglevel], msg)
   end
 end

--- a/spec/types/echo_spec.rb
+++ b/spec/types/echo_spec.rb
@@ -36,7 +36,7 @@ describe 'echo', type: :type do
   context 'with loglevel set to `crit`' do
     it 'shows a critical log message' do
       expect(Puppet).to receive(:crit).with('/Echo[TestMessage]/message: TestMessage')
-      my_type.new(name: default_title)
+      my_type.new(name: default_title, loglevel: 'crit')
     end
   end
 end

--- a/spec/types/echo_spec.rb
+++ b/spec/types/echo_spec.rb
@@ -32,4 +32,11 @@ describe 'echo', type: :type do
     end
   end
   # TODO: figure out how to test the refresh notification
+
+  context 'with loglevel set to `crit`' do
+    it 'shows a critical log message' do
+      expect(Puppet).to receive(:crit).with('/Echo[TestMessage]/message: TestMessage')
+      my_type.new(name: default_title)
+    end
+  end
 end


### PR DESCRIPTION
Can optionally set loglevel to any of `[:debug, :info, :notice, :warning, :err, :alert, :emerg, :crit]`.